### PR TITLE
運用中のラッピングトレインなどの情報をニックネームとして取り扱う

### DIFF
--- a/sqls/22-hensei-name.sql
+++ b/sqls/22-hensei-name.sql
@@ -1,0 +1,22 @@
+-- びわこ号復活プロジェクトギャラリートレイン
+-- http://www.keihan.co.jp/traffic/specialtrain-goods/exp_gallerytrain-biwako/
+-- 2207-2257
+-- 2012-10-17～2013-03-31
+UPDATE "formations"
+    SET "nickname" = 'びわこ号復活プロジェクトギャラリートレイン'
+    WHERE "id" = 2207;
+
+-- 13000 系ギャラリートレイン
+-- http://www.keihan.co.jp/traffic/specialtrain-goods/event_13000debut/
+-- 2012-04-14～2013-04-14
+UPDATE "formations"
+    SET "nickname" = 'ギャラリートレイン'
+    WHERE "id" = 13001;
+
+-- トーマスラッピング
+-- http://www.keihan.co.jp/traffic/railfan/thomas2013/
+-- 10006F, 3006F
+-- 2013-03-02～2014-03-23
+UPDATE "formations"
+    SET "nickname" = 'THOMAS&FRIENDS'
+    WHERE "id" IN (3006, 10006);


### PR DESCRIPTION
びわこ号復活プロジェクトとか
13000ギャラリートレインとか
トーマスラッピングとか
